### PR TITLE
🔥 Added `/api/v1/rfqs` route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2021-06-11
+
+### 🔥 Added
+
+- logic for listing rfqs on GET `/api/v1/rfqs` route
+- tests for listing rfqs on GET `/api/v1/rfqs` route
+
 ## [0.2.0] - 2021-06-10
 
 ### 🔥 Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "server",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "riverdi-rfq--backend",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "description": "",
   "main": "index.js",
   "engines": {

--- a/src/routes/rfq-router.ts
+++ b/src/routes/rfq-router.ts
@@ -1,9 +1,10 @@
 import express from "express";
 
-import { newRfqRouter } from "./rfqs";
+import { newRfqRouter, rfqListRouter } from "./rfqs";
 
 const app = express();
 
 app.use(newRfqRouter);
+app.use(rfqListRouter);
 
 export { app as rfqRouter };

--- a/src/routes/rfqs/index.ts
+++ b/src/routes/rfqs/index.ts
@@ -1,1 +1,2 @@
 export * from "./new";
+export * from "./list";

--- a/src/routes/rfqs/list.ts
+++ b/src/routes/rfqs/list.ts
@@ -1,0 +1,12 @@
+import express from "express";
+import { requireAuth } from "../../middlewares";
+import { RfqRepo } from "../../repos/rfq-repo";
+
+const router = express.Router();
+
+router.get("/api/v1/rfqs", requireAuth, async (req, res) => {
+  const users = await RfqRepo.find();
+  res.send(users);
+});
+
+export { router as rfqListRouter };

--- a/src/test/routes/rfqs/list.test.ts
+++ b/src/test/routes/rfqs/list.test.ts
@@ -1,0 +1,30 @@
+import request from "supertest";
+import { app } from "../../../app";
+
+it("responds with users list", async () => {
+  const cookie = await global.login();
+
+  await request(app)
+    .post("/api/v1/rfqs")
+    .set("Cookie", cookie)
+    .send({
+      eau: 2370000,
+      customer_id: 1,
+      distributor_id: 1,
+      pm_id: 1,
+      kam_id: 1,
+    })
+    .expect(201);
+
+  const response = await request(app)
+    .get("/api/v1/rfqs")
+    .set("Cookie", cookie)
+    .send()
+    .expect(200);
+
+  expect(response.body.length).toBeGreaterThan(0);
+});
+
+it("responds 401 if not authenticated", async () => {
+  const response = await request(app).get("/api/v1/rfqs").send().expect(401);
+});


### PR DESCRIPTION
- logic for listing rfqs on GET `/api/v1/rfqs` route
- tests for listing rfqs on GET `/api/v1/rfqs` route