### PR TITLE
🔥 Added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2021-06-15
+
+### 🔥 Added
+
+- logic for showing a RFQ on GET `/api/v1/rfq/:id` route
+- logic for showing a RFQ's requirements on GET `/api/v1/rfq/:id/requirements` route
+- tests for showing a RFQ on GET `/api/v1/rfq/:id` route
+- tests for showing a RFQ's requirements on GET `/api/v1/rfq/:id/requirements` route
+
 ## [0.4.0] - 2021-06-12
 
 ### 🔥 Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "riverdi-rfq--backend",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "",
   "main": "index.js",
   "engines": {

--- a/src/repos/rfq-repo.ts
+++ b/src/repos/rfq-repo.ts
@@ -6,19 +6,19 @@ class RfqRepo {
     try {
       const result = await pool.query(`
       SELECT
-      id,
+      r.id,
       rfq_code,
       eau,
       customers.name AS customer,
       distributors.name AS distributor,
       pm.shortname AS pm,
       kam.shortname AS kam,
-      to_char(rfqs.updated_at, 'YYYY-MM-DD HH24:MI:SS') as updated
-      FROM rfqs
-      JOIN customers ON customers.id = rfqs.customer_id
-      JOIN distributors ON distributors.id = rfqs.distributor_id
-      JOIN users AS pm ON pm.id = rfqs.pm_id
-      JOIN users AS kam ON kam.id = rfqs.kam_id
+      to_char(r.updated_at, 'YYYY-MM-DD HH24:MI:SS') as updated
+      FROM rfqs AS r
+      JOIN customers ON customers.id = r.customer_id
+      JOIN distributors ON distributors.id = r.distributor_id
+      JOIN users AS pm ON pm.id = r.pm_id
+      JOIN users AS kam ON kam.id = r.kam_id
       ORDER BY updated DESC;
       `);
       return result?.rows;
@@ -32,19 +32,20 @@ class RfqRepo {
       const result = await pool.query(
         `
         SELECT
-        id,
-        rfq_code,
-        eau,
-        customers.name AS customer,
-        distributors.name AS distributor,
-        pm.shortname AS pm,
-        kam.shortname AS kam
-        FROM rfqs
-        WHERE id = $1
-        JOIN customers ON customers.id = rfqs.customer_id
-        JOIN distributors ON distributors.id = rfqs.distributor_id
-        JOIN users AS pm ON pm.id = rfqs.pm_id
-        JOIN users AS kam ON kam.id = rfqs.kam_id;
+          r.id,
+          rfq_code,
+          eau,
+          customers.name AS customer,
+          distributors.name AS distributor,
+          pm.shortname AS pm,
+          kam.shortname AS kam,
+          to_char(r.updated_at, 'YYYY-MM-DD HH24:MI:SS') as updated
+          FROM rfqs AS r
+          JOIN customers ON customers.id = r.customer_id
+          JOIN distributors ON distributors.id = r.distributor_id
+          JOIN users AS pm ON pm.id = r.pm_id
+          JOIN users AS kam ON kam.id = r.kam_id
+        WHERE r.id = $1
         `,
         [id]
       );

--- a/src/routes/requirement-router.ts
+++ b/src/routes/requirement-router.ts
@@ -1,9 +1,13 @@
 import express from "express";
 
-import { newRequirementRouter } from "./requirements";
+import {
+  newRequirementRouter,
+  showRequirementsForRfqRouter,
+} from "./requirements";
 
 const app = express();
 
 app.use(newRequirementRouter);
+app.use(showRequirementsForRfqRouter);
 
 export { app as requirementRouter };

--- a/src/routes/requirements/index.ts
+++ b/src/routes/requirements/index.ts
@@ -1,1 +1,2 @@
 export * from "./new";
+export * from "./show-for-rfq";

--- a/src/routes/requirements/new.ts
+++ b/src/routes/requirements/new.ts
@@ -24,7 +24,7 @@ router.post(
       .trim()
       .notEmpty()
       .escape()
-      .withMessage("You must supply a PmId"),
+      .withMessage("You must supply a requirement"),
     body("note").trim().escape(),
   ],
   validateRequest,

--- a/src/routes/requirements/show-for-rfq.ts
+++ b/src/routes/requirements/show-for-rfq.ts
@@ -1,0 +1,13 @@
+import express from "express";
+import { requireAuth } from "../../middlewares";
+import { RequirementRepo } from "../../repos/requirement-repo";
+
+const router = express.Router();
+
+router.get("/api/v1/rfqs/:id/requirements", requireAuth, async (req, res) => {
+  const { id } = req.params;
+  const requirements = await RequirementRepo.findByRfqId(id);
+  res.send(requirements);
+});
+
+export { router as showRequirementsForRfqRouter };

--- a/src/routes/rfq-router.ts
+++ b/src/routes/rfq-router.ts
@@ -1,10 +1,11 @@
 import express from "express";
 
-import { newRfqRouter, rfqListRouter } from "./rfqs";
+import { newRfqRouter, rfqListRouter, showRfqRouter } from "./rfqs";
 
 const app = express();
 
 app.use(newRfqRouter);
 app.use(rfqListRouter);
+app.use(showRfqRouter);
 
 export { app as rfqRouter };

--- a/src/routes/rfqs/index.ts
+++ b/src/routes/rfqs/index.ts
@@ -1,2 +1,3 @@
 export * from "./new";
 export * from "./list";
+export * from "./show";

--- a/src/routes/rfqs/show.ts
+++ b/src/routes/rfqs/show.ts
@@ -1,0 +1,19 @@
+import express from "express";
+import { requireAuth } from "../../middlewares";
+import { RfqRepo } from "../../repos/rfq-repo";
+import { NotFoundError } from "../../errors";
+
+const router = express.Router();
+
+router.get("/api/v1/rfqs/:id", requireAuth, async (req, res) => {
+  const { id } = req.params;
+  const rfq = await RfqRepo.findById(id);
+
+  if (!rfq) {
+    throw new NotFoundError();
+  }
+
+  res.send(rfq);
+});
+
+export { router as showRfqRouter };

--- a/src/test/routes/auth/current-user.test.ts
+++ b/src/test/routes/auth/current-user.test.ts
@@ -9,7 +9,7 @@ it("responds with details about the current user", async () => {
     .send()
     .expect(200);
 
-  expect(response.body.currentUser.email).toEqual("test@test.com");
+  expect(response.body.currentUser.email).toEqual("test1@test.com");
 });
 
 it("responds with null if not authenticated", async () => {

--- a/src/test/routes/requirements/new.test.ts
+++ b/src/test/routes/requirements/new.test.ts
@@ -1,0 +1,114 @@
+import request from "supertest";
+import { app } from "../../../app";
+import { RequirementRepo } from "../../../repos/requirement-repo";
+
+it("creates a requirement to given rfq", async () => {
+  const cookie = await global.login();
+
+  const newRfq = await request(app)
+    .post("/api/v1/rfqs")
+    .set("Cookie", cookie)
+    .send({
+      eau: 2370000,
+      customer_id: 1,
+      distributor_id: 1,
+      pm_id: 1,
+      kam_id: 1,
+    })
+    .expect(201);
+
+  const startingCount = await RequirementRepo.count();
+  await request(app)
+    .post(`/api/v1/rfqs/requirements`)
+    .set("Cookie", cookie)
+    .send({
+      rfq_id: newRfq.body.id,
+      c_nc_cwr: "c",
+      requirement: "new req",
+      note: "new note",
+    })
+    .expect(201);
+
+  const finishCount = await RequirementRepo.count();
+  expect(finishCount - startingCount).toEqual(1);
+});
+
+it("returns a 400 with invalid c_nc_cwr", async () => {
+  const cookie = await global.login(2);
+  const newRfq = await request(app)
+    .post("/api/v1/rfqs")
+    .set("Cookie", cookie)
+    .send({
+      eau: 2370000,
+      customer_id: 1,
+      distributor_id: 1,
+      pm_id: 2,
+      kam_id: 2,
+    })
+    .expect(201);
+
+  await request(app)
+    .post(`/api/v1/rfqs/requirements`)
+    .set("Cookie", cookie)
+    .send({
+      rfq_id: newRfq.body.id,
+      c_nc_cwr: "cd",
+      requirement: "new req",
+      note: "new note",
+    })
+    .expect(400);
+});
+
+it("returns a 400 with invalid requirement", async () => {
+  const cookie = await global.login(3);
+
+  const newRfq = await request(app)
+    .post("/api/v1/rfqs")
+    .set("Cookie", cookie)
+    .send({
+      eau: 2370000,
+      customer_id: 1,
+      distributor_id: 1,
+      pm_id: 3,
+      kam_id: 3,
+    })
+    .expect(201);
+
+  await request(app)
+    .post(`/api/v1/rfqs/requirements`)
+    .set("Cookie", cookie)
+    .send({
+      rfq_id: newRfq.body.id,
+      c_nc_cwr: "c",
+      requirement: "",
+      note: "new note",
+    })
+    .expect(400);
+});
+
+it("returns a 400 with invalid rfq_id", async () => {
+  const cookie = await global.login();
+
+  await request(app)
+    .post(`/api/v1/rfqs/requirements`)
+    .set("Cookie", cookie)
+    .send({
+      rfq_id: 10000000,
+      c_nc_cwr: "c",
+      requirement: "new req",
+      note: "new note",
+    })
+    .expect(400);
+});
+
+it("responds 401 if not authenticated", async () => {
+  await request(app)
+    .post(`/api/v1/rfqs/requirements`)
+    .send({
+      rfq_id: 1,
+      c_nc_cwr: "c",
+      requirement: "new req",
+      note: "new note",
+    })
+    .expect(401);
+});

--- a/src/test/routes/requirements/show-for-rfq.test.ts
+++ b/src/test/routes/requirements/show-for-rfq.test.ts
@@ -1,0 +1,41 @@
+import request from "supertest";
+import { app } from "../../../app";
+
+it("responds with rfq details", async () => {
+  const cookie = await global.login();
+
+  const newRfq = await request(app)
+    .post("/api/v1/rfqs")
+    .set("Cookie", cookie)
+    .send({
+      eau: 2370000,
+      customer_id: 1,
+      distributor_id: 1,
+      pm_id: 1,
+      kam_id: 1,
+    })
+    .expect(201);
+
+  await request(app)
+    .post(`/api/v1/rfqs/requirements`)
+    .set("Cookie", cookie)
+    .send({
+      rfq_id: newRfq.body.id,
+      c_nc_cwr: "c",
+      requirement: "new req",
+      note: "new note",
+    })
+    .expect(201);
+
+  const response = await request(app)
+    .get(`/api/v1/rfqs/${newRfq.body.id}/requirements`)
+    .set("Cookie", cookie)
+    .send()
+    .expect(200);
+
+  expect(response.body[0].note).toEqual("new note");
+});
+
+it("responds 401 if not authenticated", async () => {
+  await request(app).get("/api/v1/rfqs/4/requirements").send().expect(401);
+});

--- a/src/test/routes/rfqs/show.test.ts
+++ b/src/test/routes/rfqs/show.test.ts
@@ -1,10 +1,10 @@
 import request from "supertest";
 import { app } from "../../../app";
 
-it("responds with rfqs list", async () => {
+it("responds with rfq details", async () => {
   const cookie = await global.login();
 
-  await request(app)
+  const newRfq = await request(app)
     .post("/api/v1/rfqs")
     .set("Cookie", cookie)
     .send({
@@ -17,14 +17,22 @@ it("responds with rfqs list", async () => {
     .expect(201);
 
   const response = await request(app)
-    .get("/api/v1/rfqs")
+    .get(`/api/v1/rfqs/${newRfq.body.id}`)
     .set("Cookie", cookie)
     .send()
     .expect(200);
+});
 
-  expect(response.body.length).toBeGreaterThan(0);
+it("responds with 404 if rfq not found", async () => {
+  const cookie = await global.login();
+
+  const response = await request(app)
+    .get(`/api/v1/rfqs/1`)
+    .set("Cookie", cookie)
+    .send()
+    .expect(404);
 });
 
 it("responds 401 if not authenticated", async () => {
-  const response = await request(app).get("/api/v1/rfqs").send().expect(401);
+  const response = await request(app).get("/api/v1/rfqs/4").send().expect(401);
 });

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -5,7 +5,7 @@ import { Context } from "./context";
 declare global {
   namespace NodeJS {
     interface Global {
-      login(): Promise<string[]>;
+      login(role_id?: number): Promise<string[]>;
     }
   }
 }
@@ -24,15 +24,15 @@ afterAll(async () => {
   await context?.close();
 });
 
-global.login = async () => {
+global.login = async (role_id = 1) => {
   const authResponse = await request(app)
     .post("/api/v1/users/signup")
     .send({
-      email: "test@test.com",
-      password: "password",
-      username: "test",
-      shortname: "QWERTY",
-      role_id: 1,
+      email: `test${role_id}@test.com`,
+      password: `password`,
+      username: `test${role_id}`,
+      shortname: `QWERTY${role_id}`,
+      role_id,
     })
     .expect(201);
 


### PR DESCRIPTION
- logic for showing a RFQ on GET `/api/v1/rfq/:id` route
- logic for showing a RFQ's requirements on GET `/api/v1/rfq/:id/requirements` route
- tests for showing a RFQ on GET `/api/v1/rfq/:id` route
- tests for showing a RFQ's requirements on GET
`/api/v1/rfq/:id/requirements` route